### PR TITLE
Update version gcc -> cc and buildgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ user = []
 dumbbuffer = []
 
 [build-dependencies]
-gcc = "0.3.32"
-bindgen = "0.19.0"
+cc = "1.0"
+bindgen = "0.65.1"
 
 [dependencies]
 libc = "0.2.15"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,10 @@
-extern crate gcc;
-extern crate bindgen;
+
+use std::path::PathBuf;
+use std::env;
 
 // Compile and link to the drm-shim
 fn compile_drm_shim() {
-    gcc::Config::new()
+    cc::Build::new()
         .file("src/ffi/cc/drm_shim.c")
         .debug(false)
         .compile("libffi.a");
@@ -11,11 +12,19 @@ fn compile_drm_shim() {
 
 // Generate rust bindings to access drm structs
 fn generate_shim_bindings() {
-    let builder = bindgen::Builder::new("src/ffi/cc/drm_shim.c");
-    match builder.generate() {
-        Ok(b) => b.write_to_file("src/ffi/drm_shim.rs").unwrap(),
-        Err(e) => panic!(e)
-    };
+    let bindings = bindgen::Builder::default()
+        .header("src/ffi/cc/drm_shim.c")
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings");
+
+//    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+//    bindings
+//        .write_to_file(out_path.join("drm_shim.rs"))
+//        .expect("Couldn't write bindings!");
+    bindings
+        .write_to_file("src/ffi/drm_shim.rs")
+        .expect("Couldn't write bindings!");
 }
 
 pub fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,35 +404,35 @@ impl<'a> Connectors<'a> {
 #[derive(Debug, PartialEq, Clone, Copy)]
 /// The type of interface a `Connector` is.
 pub enum ConnectorInterface {
-    Unknown = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_Unknown as isize,
-    VGA = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_VGA as isize,
-    DVII = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_DVII as isize,
-    DVID = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_DVID as isize,
-    DVIA = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_DVIA as isize,
-    Composite = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_Composite as isize,
-    SVideo = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_SVIDEO as isize,
-    LVDS = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_LVDS as isize,
-    Component = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_Component as isize,
-    NinePinDIN = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_9PinDIN as isize,
-    DisplayPort = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_DisplayPort as isize,
-    HDMIA = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_HDMIA as isize,
-    HDMIB = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_HDMIB as isize,
-    TV = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_TV as isize,
-    EDP = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_eDP as isize,
-    Virtual = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_VIRTUAL as isize,
-    DSI = ffi::ConnectorInterface::FFI_DRM_MODE_CONNECTOR_DSI as isize,
+    Unknown = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_Unknown as isize,
+    VGA = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_VGA as isize,
+    DVII = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_DVII as isize,
+    DVID = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_DVID as isize,
+    DVIA = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_DVIA as isize,
+    Composite = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_Composite as isize,
+    SVideo = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_SVIDEO as isize,
+    LVDS = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_LVDS as isize,
+    Component = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_Component as isize,
+    NinePinDIN = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_9PinDIN as isize,
+    DisplayPort = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_DisplayPort as isize,
+    HDMIA = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_HDMIA as isize,
+    HDMIB = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_HDMIB as isize,
+    TV = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_TV as isize,
+    EDP = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_eDP as isize,
+    Virtual = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_VIRTUAL as isize,
+    DSI = ffi::ConnectorInterface_FFI_DRM_MODE_CONNECTOR_DSI as isize,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 /// The state of a `Connector`.
 pub enum ConnectorState {
     /// The `Connector` is plugged in and ready for use.
-    Connected = ffi::Connection::FFI_DRM_MODE_CONNECTED as isize,
+    Connected = ffi::Connection_FFI_DRM_MODE_CONNECTED as isize,
     /// The `Connector` is unplugged.
-    Disconnected = ffi::Connection::FFI_DRM_MODE_DISCONNECTED as isize,
+    Disconnected = ffi::Connection_FFI_DRM_MODE_DISCONNECTED as isize,
     /// Sometimes a `Connector` will have an unkown state. It is safe to use,
     /// but may not provide the expected functionality.
-    Unknown = ffi::Connection::FFI_DRM_MODE_UNKNOWN as isize
+    Unknown = ffi::Connection_FFI_DRM_MODE_UNKNOWN as isize
 }
 
 impl From<u32> for ConnectorInterface {


### PR DESCRIPTION
Changes:

* Replace `gcc` -> `cc` crate
* Update `buildgen` version

Known issues:

1. No `Error` in this scope
```
error[E0412]: cannot find type `Error` in this scope
  --> src/result.rs:1:1
   |
1  | / error_chain! {
2  | |     foreign_links {
3  | |         ::std::io::Error, IoError;
4  | |     }
...  |
15 | |     }
16 | | }
   | |_^ not found in this scope

```
2. No default implementation
```
error[E0277]: the trait bound `drm_shim::drm_mode_destroy_dumb: Default` is not satisfied
   --> src/ffi/mod.rs:248:46
    |
248 |         let mut raw: drm_mode_destroy_dumb = Default::default();
    |                                              ^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `drm_shim::drm_mode_destroy_dumb`

```